### PR TITLE
Make page paths globally unique and randomize on creation

### DIFF
--- a/app/components/Layout/Dashboard-header.tsx
+++ b/app/components/Layout/Dashboard-header.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Menu, Sparkles } from "lucide-react";
+import GenioLogo from "../LogoGenio";
 
 interface DashboardHeaderProps {
   sidebarOpen: boolean;
@@ -25,8 +26,8 @@ export default function DashboardHeader({
           onClick={() => (window.location.href = "/")}
           className="transition-transform duration-300 hover:rotate-12 hover:scale-110 cursor-pointer"
         >
-          <div className="w-10 h-10 bg-primary rounded-lg flex items-center justify-center">
-            <Sparkles className="text-primary-foreground" size={24} />
+          <div className="w-10 h-10 rounded-lg flex items-center justify-center">
+            <GenioLogo variant="simplified"/>
           </div>
         </div>
         <h1 className="text-2xl font-bold text-primary">GENIO</h1>

--- a/app/components/Layout/Header.jsx
+++ b/app/components/Layout/Header.jsx
@@ -64,7 +64,7 @@ const Header = () => {
             </button>
 
             <button
-              onClick={() => (window.location.href = "/dashboard")}
+              onClick={() => (window.location.href = "/login")}
               className="bg-gradient-to-r from-purple-500 to-pink-500 text-white px-6 py-2.5 rounded-full font-medium hover:scale-105 hover:shadow-lg transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2"
             >
               Probar Gratis

--- a/app/components/LogoGenio.tsx
+++ b/app/components/LogoGenio.tsx
@@ -162,7 +162,7 @@ const GenioLogo = ({
 
   const variants = {
     full: <FullSVG />,
-    simplified: <SimplifiedSVG />,
+    simplified: <SimplifiedSVG isMono={undefined} title={undefined} />,
     lettermark: <LettermarkSVG />,
   };
 

--- a/app/dashboard/new/page.tsx
+++ b/app/dashboard/new/page.tsx
@@ -3,8 +3,9 @@ import { prisma } from "@/lib/prisma";
 import { redirect } from "next/navigation";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
-import TitleField from "./TitleField";
-import { toSlug } from "@/lib/slug";
+import { customAlphabet } from "nanoid";
+
+const nanoid = customAlphabet("0123456789abcdefghijklmnopqrstuvwxyz", 12);
 
 export default async function NewSitePage() {
   async function create(formData: FormData) {
@@ -14,47 +15,34 @@ export default async function NewSitePage() {
     const email = session?.user?.email;
     if (!email) redirect("/login");
 
-    const user = await prisma.user.findUnique({
-      where: { email },
-      select: { id: true },
-    });
+    const user = await prisma.user.findUnique({ where: { email }, select: { id: true } });
     if (!user) redirect("/login");
 
-    const title = String(formData.get("title") || "").trim() || "Mi sitio";
-    const slug = toSlug(title);
+    const title = (formData.get("title") as string)?.trim() || "Mi sitio";
 
-    // Comprobación definitiva en servidor
-    const exists = await prisma.page.findFirst({
-      where: { userId: user.id, path: slug },
-      select: { id: true },
-    });
-    if (exists) {
-      // vuelve a la pantalla con un mensaje
-      redirect("/dashboard/new?error=duplicate");
+    // Generar path aleatorio y comprobar colisión
+    let path = `/${nanoid()}`;
+    while (await prisma.page.findUnique({ where: { path } })) {
+      path = `/${nanoid()}`;
     }
 
     await prisma.page.create({
       data: {
         title,
-        path: slug,
+        path,         // <- aleatorio, NO del título
         userId: user.id,
         content: { root: { type: "container", props: { title }, children: [] } },
       },
     });
 
-    // El middleware reescribe /slug/edit → /puck/slug
-    redirect(`${slug}/edit`);
+    redirect(`${path}/edit`); // middleware reescribe a /puck/<path>
   }
 
-  // puedes leer el error opcional
-  // const search = await import("next/navigation").then(m => m.searchParams()) ... (si te interesa mostrar algo)
   return (
     <form action={create} className="max-w-md mx-auto p-6 space-y-4">
       <h1 className="text-xl font-bold">Nuevo sitio</h1>
-      <TitleField />
-      <button className="px-4 py-2 rounded bg-purple-600 text-white">
-        Crear y editar
-      </button>
+      <input name="title" placeholder="Nombre del sitio" className="w-full border p-2 rounded" />
+      <button className="px-4 py-2 rounded bg-purple-600 text-white">Crear y editar</button>
     </form>
   );
 }

--- a/app/login/AuthForm.jsx
+++ b/app/login/AuthForm.jsx
@@ -220,7 +220,7 @@ const handleRegister = async (e) => {
         <div className="relative w-full h-[600px] bg-white/90 backdrop-blur-xl rounded-2xl shadow-2xl border border-white/20 overflow-hidden transition-all duration-500 hover:shadow-3xl hover:scale-[1.01]">
           <div className="absolute top-6 left-6 z-50 flex items-center space-x-3 bg-white/95 backdrop-blur-sm px-4 py-3 rounded-xl shadow-lg transition-all duration-300 hover:-translate-y-1 hover:shadow-xl border border-white/30">
             <div onClick={() => (window.location.href = "/")} className="transition-transform duration-300 hover:rotate-12 hover:scale-110">
-              <LogoGenio></LogoGenio>
+              <LogoGenio variant="simplified" />
             </div>
             <span className="text-xl font-bold bg-gradient-to-r from-purple-600 to-pink-600 bg-clip-text text-transparent">
               GENIO

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "clsx": "^2.1.1",
         "jsonwebtoken": "^9.0.2",
         "lucide-react": "^0.539.0",
+        "nanoid": "^5.1.6",
         "next": "^15.2.4",
         "next-auth": "^4.24.11",
         "postcss": "^8.5.6",
@@ -4931,9 +4932,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.6.tgz",
+      "integrity": "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==",
       "funding": [
         {
           "type": "github",
@@ -4942,10 +4943,10 @@
       ],
       "license": "MIT",
       "bin": {
-        "nanoid": "bin/nanoid.cjs"
+        "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": "^18 || >=20"
       }
     },
     "node_modules/natural-compare": {
@@ -5047,6 +5048,24 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/next/node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/next/node_modules/postcss": {
@@ -5678,6 +5697,24 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/postgres-array": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "clsx": "^2.1.1",
     "jsonwebtoken": "^9.0.2",
     "lucide-react": "^0.539.0",
+    "nanoid": "^5.1.6",
     "next": "^15.2.4",
     "next-auth": "^4.24.11",
     "postcss": "^8.5.6",

--- a/prisma/migrations/20251021050742_unique_path_global/migration.sql
+++ b/prisma/migrations/20251021050742_unique_path_global/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[path]` on the table `Page` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "public"."Page_userId_path_key";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Page_path_key" ON "public"."Page"("path");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,16 +28,11 @@ model User {
 model Page {
   id        Int      @id @default(autoincrement())
   title     String
-  path      String
+  path      String   @unique        
   content   Json
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   userId    Int
   user      User     @relation(fields: [userId], references: [id])
-
-  @@unique([userId, path]) 
-  /*esto asegura que cada usuario tenga rutas unicas para sus paginas es decir
-  que varios usuarios puedan tener la misma ruta pero un mismo usuario no pueda
-  tener dos paginas con la misma ruta*/
-  
 }
+


### PR DESCRIPTION
Migrates the Page model to enforce a global unique constraint on the 'path' field, removing the per-user uniqueness. Updates page creation to use a random nanoid-based path instead of a slug from the title. Refactors authentication to rely solely on NextAuth, simplifies middleware, and updates all relevant logic and UI to support the new path scheme. Also updates dependencies to include nanoid.